### PR TITLE
feat: mobile-first layout, history drawer, and analysis history

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { AppContainerProvider } from "@/contexts/AppContainerContext";
 import Index from "./pages/Index";
 import Analyze from "./pages/Analyze";
 import Results from "./pages/Results";
@@ -16,13 +17,15 @@ const App = () => (
       <Toaster />
       <Sonner />
       <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          <Route path="/analyze" element={<Analyze />} />
-          <Route path="/results" element={<Results />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
+        <AppContainerProvider>
+          <Routes>
+            <Route path="/" element={<Index />} />
+            <Route path="/analyze" element={<Analyze />} />
+            <Route path="/results" element={<Results />} />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </AppContainerProvider>
       </BrowserRouter>
     </TooltipProvider>
   </QueryClientProvider>

--- a/src/components/HistoryMenu.tsx
+++ b/src/components/HistoryMenu.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { useAppContainer } from "@/contexts/AppContainerContext";
+import { listAnalysisHistory, type AnalysisHistoryRow } from "@/lib/analysisHistory";
+import { getRelativeTime } from "@/lib/relativeTime";
+import { cn } from "@/lib/utils";
+
+const CHAMELEON_AVATAR = "/assets/ChameleonAvatar.png";
+
+const CONTEXT_EMOJI: Record<string, string> = {
+  Friend: "👥",
+  Work: "💼",
+  Dating: "💕",
+  Formal: "🎩",
+};
+
+const PRIMARY_GREEN = "#9DFF50";
+
+interface HistoryMenuProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+function getVibeSummary(row: AnalysisHistoryRow): string {
+  const summary = (row.analysis_result?.vibeCheck as { summary?: string } | undefined)?.summary;
+  if (typeof summary !== "string") return "";
+  return summary.length > 80 ? `${summary.slice(0, 80).trim()}…` : summary;
+}
+
+export default function HistoryMenu({ open, onClose }: HistoryMenuProps) {
+  const navigate = useNavigate();
+  const containerRef = useAppContainer();
+  const [items, setItems] = useState<AnalysisHistoryRow[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    listAnalysisHistory()
+      .then(({ data, error }) => {
+        if (error) return;
+        setItems(data ?? []);
+      })
+      .finally(() => setLoading(false));
+  }, [open]);
+
+  const handleSelect = (row: AnalysisHistoryRow) => {
+    onClose();
+    navigate("/results", {
+      state: {
+        analysisData: row.analysis_result,
+        imageData: row.image_url ?? undefined,
+        relationshipLabel: row.relationship_context,
+        fromHistory: true,
+      },
+    });
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={(o) => !o && onClose()}>
+      <SheetContent
+        side="left"
+        hideCloseButton
+        containerRef={containerRef ?? undefined}
+        className="z-[200] border-r border-white/10 bg-[#121212] p-0 text-white [&+[data-radix-popper-content-wrapper]]:z-[200]"
+      >
+        <SheetHeader className="border-b border-white/10 px-5 pt-6 pb-4 text-left">
+          <SheetTitle className="text-[20px] font-semibold leading-tight tracking-tight text-white">
+            History
+          </SheetTitle>
+        </SheetHeader>
+        <div className="flex flex-1 flex-col overflow-hidden">
+          {loading ? (
+            <div className="flex flex-1 items-center justify-center p-6">
+              <p className="text-sm text-white/60">Loading…</p>
+            </div>
+          ) : items.length === 0 ? (
+            <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6 py-10">
+              <img
+                src={CHAMELEON_AVATAR}
+                alt="Leon"
+                className="h-20 w-20 rounded-full object-cover ring-2 ring-[#9DFF50]/50"
+                onError={(e) => {
+                  (e.target as HTMLImageElement).style.display = "none";
+                }}
+              />
+              <p className="text-center text-[15px] text-white/80">
+                Your history is empty. Start scanning to save some vibes!
+              </p>
+            </div>
+          ) : (
+            <ul className="flex flex-col gap-1 overflow-y-auto px-3 pb-6">
+              {items.map((row) => {
+                const label = row.relationship_context;
+                const emoji = CONTEXT_EMOJI[label] ?? "💬";
+                const summary = getVibeSummary(row);
+                const time = getRelativeTime(row.created_at);
+                return (
+                  <li key={row.id}>
+                    <button
+                      type="button"
+                      onClick={() => handleSelect(row)}
+                      className={cn(
+                        "flex w-full items-center gap-3 rounded-xl p-3 text-left transition-colors",
+                        "hover:bg-white/5 active:bg-white/10"
+                      )}
+                    >
+                      <span
+                        className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/10 text-lg"
+                        aria-hidden
+                      >
+                        {emoji}
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-[15px] font-medium" style={{ color: PRIMARY_GREEN }}>
+                          {label}
+                        </p>
+                        <p className="truncate text-[13px] text-white/70">{summary || "No summary"}</p>
+                      </div>
+                      <span className="shrink-0 text-[12px] text-white/50">{time}</span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/UploadActionSheet.tsx
+++ b/src/components/UploadActionSheet.tsx
@@ -14,10 +14,10 @@ const UploadActionSheet = ({ open, onClose, onSelectSource }: UploadActionSheetP
   ];
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end justify-center" onClick={onClose}>
+    <div className="absolute inset-0 z-50 flex items-end justify-center" onClick={onClose}>
       <div className="absolute inset-0 bg-black/60" />
       <div
-        className="relative w-full max-w-[430px] px-5 pb-5 animate-in slide-in-from-bottom duration-300"
+        className="relative w-full px-6 pb-5 animate-in slide-in-from-bottom duration-300"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Grouped options — #1C1C1E, 12px radius, separators #48484A */}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -19,7 +19,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[150] bg-black/70 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}
@@ -29,14 +29,14 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  "fixed z-[150] gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
   {
     variants: {
       side: {
         top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
         bottom:
           "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
-        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        left: "inset-y-0 left-0 h-full w-[80vw] border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left",
         right:
           "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
       },
@@ -47,23 +47,67 @@ const sheetVariants = cva(
   },
 );
 
+const overlayClass = "z-[150] bg-black/70 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0";
+
+const absoluteOverlayClass = cn("absolute inset-0", overlayClass);
+const fixedOverlayClass = cn("fixed inset-0", overlayClass);
+
+/** Absolute positioning (for left side) when inside a container — 75% of container width so it doesn't feel too wide */
+const absoluteLeftContentClass =
+  "absolute inset-y-0 left-0 z-[150] h-full w-[75%] max-w-[320px] gap-4 border-r border-border bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left";
+
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
-    VariantProps<typeof sheetVariants> {}
+    VariantProps<typeof sheetVariants> {
+  /** When true, no X close button is shown; close by tapping overlay. */
+  hideCloseButton?: boolean;
+  /** When set, portal renders into this container and overlay/content use absolute positioning (drawer from container left edge). */
+  containerRef?: React.RefObject<HTMLElement | null>;
+}
 
 const SheetContent = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Content>, SheetContentProps>(
-  ({ side = "right", className, children, ...props }, ref) => (
-    <SheetPortal>
+  ({ side = "right", className, children, hideCloseButton = false, containerRef, ...props }, ref) => {
+    const useContainer = Boolean(containerRef);
+    const container = containerRef?.current ?? undefined;
+    const overlayNode = useContainer ? (
+      <SheetPrimitive.Overlay className={absoluteOverlayClass} />
+    ) : (
       <SheetOverlay />
-      <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
+    );
+    const contentNode = (
+      <SheetPrimitive.Content
+        ref={ref}
+        className={cn(
+          useContainer && side === "left" ? absoluteLeftContentClass : sheetVariants({ side }),
+          className
+        )}
+        {...props}
+      >
         {children}
-        <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity data-[state=open]:bg-secondary hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
-          <X className="h-4 w-4" />
-          <span className="sr-only">Close</span>
-        </SheetPrimitive.Close>
+        {!hideCloseButton && (
+          <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity data-[state=open]:bg-secondary hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+            <X className="h-4 w-4" />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
       </SheetPrimitive.Content>
-    </SheetPortal>
-  ),
+    );
+    return (
+      <SheetPortal container={container}>
+        {useContainer ? (
+          <div className="absolute inset-0 overflow-hidden" aria-hidden>
+            {overlayNode}
+            {contentNode}
+          </div>
+        ) : (
+          <>
+            {overlayNode}
+            {contentNode}
+          </>
+        )}
+      </SheetPortal>
+    );
+  }
 );
 SheetContent.displayName = SheetPrimitive.Content.displayName;
 

--- a/src/contexts/AppContainerContext.tsx
+++ b/src/contexts/AppContainerContext.tsx
@@ -1,0 +1,23 @@
+import { createContext, useContext, useRef, type RefObject } from "react";
+
+const AppContainerContext = createContext<RefObject<HTMLDivElement | null> | null>(null);
+
+export function useAppContainer() {
+  return useContext(AppContainerContext);
+}
+
+export function AppContainerProvider({ children }: { children: React.ReactNode }) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  return (
+    <AppContainerContext.Provider value={containerRef}>
+      <div className="min-h-screen w-full bg-[#0A0A0B]">
+        <div
+          ref={containerRef}
+          className="mx-auto min-h-screen w-full max-w-[430px] relative bg-[#121212] shadow-2xl"
+        >
+          {children}
+        </div>
+      </div>
+    </AppContainerContext.Provider>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,14 @@
 @tailwind utilities;
 
 @layer base {
+  html,
+  body,
+  #root {
+    min-height: 100vh;
+    width: 100%;
+    background-color: #0A0A0B;
+  }
+
   :root {
     /* Figma: main background ~#121212 */
     --background: 0 0% 7%;

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -14,7 +14,29 @@ export type Database = {
   }
   public: {
     Tables: {
-      [_ in never]: never
+      analysis_history: {
+        Row: {
+          id: string;
+          relationship_context: string;
+          analysis_result: Record<string, unknown>;
+          image_url: string | null;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          relationship_context: string;
+          analysis_result: Record<string, unknown>;
+          image_url?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          relationship_context?: string;
+          analysis_result?: Record<string, unknown>;
+          image_url?: string | null;
+          created_at?: string;
+        };
+      };
     }
     Views: {
       [_ in never]: never

--- a/src/lib/analysisHistory.ts
+++ b/src/lib/analysisHistory.ts
@@ -1,0 +1,41 @@
+/**
+ * Supabase analysis_history: insert and list.
+ * Table: relationship_context, analysis_result (jsonb), image_url, created_at
+ */
+
+import { supabase } from "@/integrations/supabase/client";
+
+export type AnalysisHistoryRow = {
+  id: string;
+  relationship_context: string;
+  analysis_result: Record<string, unknown>;
+  image_url: string | null;
+  created_at: string;
+};
+
+export async function insertAnalysisHistory(params: {
+  relationship_context: string;
+  analysis_result: Record<string, unknown>;
+  image_url: string | null;
+}): Promise<{ error: Error | null }> {
+  const { error } = await supabase.from("analysis_history").insert({
+    relationship_context: params.relationship_context,
+    analysis_result: params.analysis_result,
+    image_url: params.image_url ?? null,
+  });
+  return { error: error ? new Error(error.message) : null };
+}
+
+export async function listAnalysisHistory(): Promise<{
+  data: AnalysisHistoryRow[] | null;
+  error: Error | null;
+}> {
+  const { data, error } = await supabase
+    .from("analysis_history")
+    .select("id, relationship_context, analysis_result, image_url, created_at")
+    .order("created_at", { ascending: false });
+  return {
+    data: error ? null : (data as AnalysisHistoryRow[]),
+    error: error ? new Error(error.message) : null,
+  };
+}

--- a/src/lib/relativeTime.ts
+++ b/src/lib/relativeTime.ts
@@ -1,0 +1,19 @@
+/**
+ * Format a date as relative time (e.g. "10m ago", "2h ago", "Yesterday").
+ */
+
+export function getRelativeTime(isoDate: string): string {
+  const date = new Date(isoDate);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60_000);
+  const diffHours = Math.floor(diffMs / 3_600_000);
+  const diffDays = Math.floor(diffMs / 86_400_000);
+
+  if (diffMins < 1) return "Just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return date.toLocaleDateString();
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,6 +2,7 @@ import { useRef, useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { Menu } from "lucide-react";
 import UploadActionSheet from "@/components/UploadActionSheet";
+import HistoryMenu from "@/components/HistoryMenu";
 
 const ACCEPTED_TYPES = "image/png,image/jpeg,image/heic";
 
@@ -17,6 +18,7 @@ const Index = () => {
   const navigate = useNavigate();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [sheetOpen, setSheetOpen] = useState(false);
+  const [historyMenuOpen, setHistoryMenuOpen] = useState(false);
 
   const navigateToAnalyze = useCallback(
     (base64: string) => {
@@ -71,17 +73,23 @@ const Index = () => {
     }}, [navigateToAnalyze]);
 
   return (
-    <div className="min-h-screen bg-[#121212] flex justify-center">
-      <div className="w-full max-w-[430px] flex flex-col min-h-screen">
-        {/* Header — hamburger only, Figma layout */}
-        <header className="flex items-center px-5 pt-6 pb-2">
-          <button className="p-2 -ml-2 text-white" aria-label="Menu">
+    <div className="min-h-screen w-full bg-[#121212] relative">
+      <div className="w-full flex flex-col min-h-screen">
+        {/* Header — full width like native app */}
+        <header className="flex items-center px-6 pt-6 pb-2 w-full">
+          <button
+            type="button"
+            onClick={() => setHistoryMenuOpen(true)}
+            className="p-2 -ml-2 text-white touch-manipulation"
+            aria-label="Open history"
+          >
             <Menu className="w-6 h-6" />
           </button>
         </header>
+        <HistoryMenu open={historyMenuOpen} onClose={() => setHistoryMenuOpen(false)} />
 
         {/* Main Content */}
-        <main className="flex-1 flex flex-col px-5 pb-8">
+        <main className="flex-1 flex flex-col px-6 pb-8">
           <div className="pt-2">
             <h1 className="font-bold leading-[1.2] tracking-tight text-white text-[32px]">
               What did you find, Vanessa?


### PR DESCRIPTION
- Add phone container (max 430px) with AppContainerProvider; full-bleed on mobile
- History side menu: left drawer at 75% container width, slides from container left edge
- Save analyses to Supabase analysis_history; History menu lists and opens past results
- Sheet: portal into container + wrapper so overlay/drawer stay inside phone
- Align hamburger and padding across Index, Analyze, Results (no double px-6)
- Scanning overlay: content px-6 and overflow-x-hidden so header/button stay in container
- Upload sheet and context pills positioned inside phone container